### PR TITLE
fix:Could not find "client" ...

### DIFF
--- a/src/helpers/with-data.tsx
+++ b/src/helpers/with-data.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { ApolloProvider } from '@apollo/react-common';
+import { ApolloProvider } from '@apollo/react-hooks';
 import { getDataFromTree } from '@apollo/react-ssr';
 import { NormalizedCacheObject } from 'apollo-cache-inmemory/lib/types';
 import { ApolloClient } from 'apollo-client';


### PR DESCRIPTION
When I run a race,An error：Could not find "client" in the context or passed in as an option. Wrap the root component in an <ApolloProvider>, or pass an ApolloClient instance in via options.
The problem may be a version problem，I replaced the ApolloProvider The introduction of @apollo/react-hooks